### PR TITLE
get around strict aws cors settings on local dev server

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -4,9 +4,9 @@ import { RequestInit, MetricsResponse } from './api.types'
 // so that we proxy those calls through vite local server to get around cors on aws
 // endpoints being are allowed only on specific domains (see proxy in vite.config.ts)
 const METRICS_ORIGIN = import.meta.env.DEV
-  ? window.location.origin + "/metrics"
-  : import.meta.env.VITE_METRICS_ORIGIN ??
-    "https://ln3tnkd4d5uiufjgimi6jlkmci0bceff.lambda-url.us-west-2.on.aws/";
+    ? window.location.origin + '/metrics'
+    : import.meta.env.VITE_METRICS_ORIGIN ??
+    'https://ln3tnkd4d5uiufjgimi6jlkmci0bceff.lambda-url.us-west-2.on.aws/'
 
 /**
  * Fetch API wrapper that throws on 400+ http status.

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,12 @@
 import { RequestInit, MetricsResponse } from './api.types'
 
-const METRICS_ORIGIN = import.meta.env.VITE_METRICS_ORIGIN ?? 'https://ln3tnkd4d5uiufjgimi6jlkmci0bceff.lambda-url.us-west-2.on.aws/'
+// on localhost (dev env) we need to set the metrics origin to local /metrics endpoint
+// so that we proxy those calls through vite local server to get around cors on aws
+// endpoints being are allowed only on specific domains (see proxy in vite.config.ts)
+const METRICS_ORIGIN = import.meta.env.DEV
+  ? window.location.origin + "/metrics"
+  : import.meta.env.VITE_METRICS_ORIGIN ??
+    "https://ln3tnkd4d5uiufjgimi6jlkmci0bceff.lambda-url.us-west-2.on.aws/";
 
 /**
  * Fetch API wrapper that throws on 400+ http status.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,20 +1,33 @@
 import * as path from 'path'
 
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ command, mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+
+  return {
     // saturn-l2 depends on this path
     base: '/webui/',
     plugins: [react()],
     server: {
         port: 3010,
-        strictPort: true
+        strictPort: true,
+        // proxy for aws metrics endpoint to get around strict cors settings when developing locally
+        proxy: {
+          "/metrics": {
+            target: env.VITE_METRICS_ORIGIN ?? "https://ln3tnkd4d5uiufjgimi6jlkmci0bceff.lambda-url.us-west-2.on.aws/",
+            changeOrigin: true,
+            secure: false,
+            rewrite: (path) => path.replace(/^\/metrics/, ""),
+          },
+        },
     },
     resolve: {
         alias: {
             '@': path.resolve(__dirname, './src')
         }
     }
+  }
 })


### PR DESCRIPTION
when running local dev server, trying to access aws endpoint ends up with cors not allowed issue due to strict origin policy

> Access to fetch at 'https://ln3tnkd4d5uiufjgimi6jlkmci0bceff.lambda-url.us-west-2.on.aws/?filAddress=REDACTED_FIL_WALLET_ADDRESS&startDate=1668523800000&endDate=1669128600000&step=hour' from origin 'http://localhost:3010' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.

I'm not familiar with the aws codebase yet but it seems like this is the commit that might have broken the local dev server https://github.com/filecoin-saturn/terraform/commit/a20dba0993f1aafca5177e9f9c9378c0403ac598

This pull request adds a local rewrite on dev server that gets around the cors aws settings and allows to use remote aws test endpoint. It does not have any impact on production build.
