### PR TITLE
accept any 2xx status on login endpoint

### DIFF
--- a/src/services/statsAuthorization.ts
+++ b/src/services/statsAuthorization.ts
@@ -4,7 +4,7 @@ export default async function getAuthorizationToken(username: string, password: 
     headers: { Authorization: authorizationToken },
   });
 
-  if (response.status === 200) {
+  if (response.ok) {
     return authorizationToken;
   }
 


### PR DESCRIPTION
- prepare for /login to respond with 204 No Content
- accept any 2xx response code with [`response.ok`](https://developer.mozilla.org/en-US/docs/Web/API/Response/ok)