### PR TITLE
auto adjust column size on filter change

### DIFF
--- a/src/components/StatsGrid/StatsGrid.tsx
+++ b/src/components/StatsGrid/StatsGrid.tsx
@@ -60,6 +60,7 @@ export default function StatsGrid() {
           onModelUpdated={autoSizeAllColumns}
           onGridSizeChanged={autoSizeAllColumns}
           onFirstDataRendered={autoSizeAllColumns}
+          onFilterChanged={autoSizeAllColumns}
           getRowId={(params) => params.data.id}
           onGridReady={onGridReady}
           tooltipShowDelay={0}


### PR DESCRIPTION
currently when you filter, column widths will revert to defaults and result in truncated content in cells - we need to call a method to auto size the columns again like we do in other cases 