### PR TITLE
auto size all columns with a delay

### DIFF
--- a/src/components/StatsGrid/StatsGrid.tsx
+++ b/src/components/StatsGrid/StatsGrid.tsx
@@ -22,7 +22,7 @@ export default function StatsGrid() {
 
   const autoSizeAllColumns = useCallback(() => {
     if (columnApi) {
-      columnApi.autoSizeAllColumns();
+      setTimeout(() => columnApi.autoSizeAllColumns(), 0);
     }
   }, [columnApi]);
 


### PR DESCRIPTION
when sorting the stats grid (by clicking on a sortable column header), columns are not being properly auto sized and some of the data gets truncated

due to rows virtualisation (I suspect), when sorting old rows (not rendered any more) are taken into account and columns width is not being properly calculated - to overcome that issue, columns width recalculation function [autoSizeAllColumns](https://www.ag-grid.com/javascript-data-grid/column-api/#reference-Sizing-autoSizeAllColumns) should be moved to next event loop (setTimeout with 0 timeout)

in `src/components/StatsGrid/StatsGrid.tsx` there is a callback function `autoSizeAllColumns` that internally calls grid's `columnApi.autoSizeAllColumns()`. This function is assigned as an event callback for `onModelUpdated`, `onGridSizeChanged`, `onFirstDataRendered` and `onFilterChanged`. There are also events `postSort`, `postSortRows` and `onSortChanged` but auto sizing on those events without `setTimeout` hack did not work correctly either and `onModelUpdated` gets called after the data is sorted anyway so there was no need to assign additional callbacks

note: rows virtualisation should not be disabled, grid with 1000+ rows will have very poor load and usage performance
https://www.ag-grid.com/react-data-grid/dom-virtualisation/