### PR TITLE
feat: Support per node stats for a given fil address. 

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -7,9 +7,6 @@ const METRICS_ORIGIN = import.meta.env.DEV
   ? window.location.origin + "/metrics"
   : import.meta.env.VITE_METRICS_ORIGIN ?? "https://ln3tnkd4d5uiufjgimi6jlkmci0bceff.lambda-url.us-west-2.on.aws/";
 
-// The current setup for local testing uses a Lambda gateway that
-// does not parse the requests to lambda events.
-const IS_LOCAL_LAMBDA = import.meta.env.VITE_LOCAL_GATEWAY;
 /**
  * Fetch API wrapper that throws on 400+ http status.
  */
@@ -18,15 +15,6 @@ export async function wfetch(resource: RequestInfo | URL, opts: RequestInit = {}
     const controller = new AbortController();
     opts.signal = controller.signal;
     setTimeout(() => controller.abort(), opts.timeout);
-  }
-
-  if (IS_LOCAL_LAMBDA) {
-    opts.headers = {
-      "Content-Type": "application/json",
-    };
-
-    opts.body = JSON.stringify(dataObj);
-    opts.method = "POST";
   }
 
   const response = await fetch(resource, opts);
@@ -71,9 +59,6 @@ export async function fetchMetrics(
 
   const res: FetchAllResponse = await wfetch(url, { signal }, dataObj).then((r) => r.json());
 
-  // Uncomment for local testing
-  // res = res.data?.body;
-
   res.earnings.forEach((e) => {
     e.timestamp = new Date(e.timestamp);
   });
@@ -111,9 +96,6 @@ export async function fetchNodeMetrics(
   url.searchParams.set("step", step);
 
   const res: MetricsResponse = await wfetch(url, { signal }, dataObj).then((r) => r.json());
-
-  // Uncomment for local testing
-  // res = res.data?.body;
 
   res.earnings.forEach((e) => {
     e.timestamp = new Date(e.timestamp);

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import { RequestInit, MetricsResponse } from "./api.types";
+import { RequestInit, MetricsResponse, FetchAllResponse } from "./api.types";
 
 // on localhost (dev env) we need to set the metrics origin to local /metrics endpoint
 // so that we proxy those calls through vite local server to get around cors on aws
@@ -7,14 +7,26 @@ const METRICS_ORIGIN = import.meta.env.DEV
   ? window.location.origin + "/metrics"
   : import.meta.env.VITE_METRICS_ORIGIN ?? "https://ln3tnkd4d5uiufjgimi6jlkmci0bceff.lambda-url.us-west-2.on.aws/";
 
+// The current setup for local testing uses a Lambda gateway that
+// does not parse the requests to lambda events.
+const IS_LOCAL_LAMBDA = import.meta.env.LOCAL_GATEWAY;
 /**
  * Fetch API wrapper that throws on 400+ http status.
  */
-export async function wfetch(resource: RequestInfo | URL, opts: RequestInit = {}) {
+export async function wfetch(resource: RequestInfo | URL, opts: RequestInit = {}, dataObj: object = {}) {
   if (Number.isFinite(opts.timeout)) {
     const controller = new AbortController();
     opts.signal = controller.signal;
     setTimeout(() => controller.abort(), opts.timeout);
+  }
+
+  if (IS_LOCAL_LAMBDA) {
+    opts.headers = {
+      "Content-Type": "application/json",
+    };
+
+    opts.body = JSON.stringify(dataObj);
+    opts.method = "POST";
   }
 
   const response = await fetch(resource, opts);
@@ -28,7 +40,6 @@ export async function wfetch(resource: RequestInfo | URL, opts: RequestInit = {}
 
     throw new Error(message);
   }
-
   return response;
 }
 
@@ -40,12 +51,63 @@ export async function fetchMetrics(
   signal: AbortSignal
 ) {
   const url = new URL(METRICS_ORIGIN);
+
+  // This is only used for local testing.
+  const dataObj = {
+    event: {
+      queryStringParameters: {
+        filAddress,
+        startDate: startDate.getTime(),
+        endDate: endDate.getTime(),
+        step,
+      },
+    },
+  };
+
   url.searchParams.set("filAddress", filAddress);
   url.searchParams.set("startDate", `${startDate.getTime()}`);
   url.searchParams.set("endDate", `${endDate.getTime()}`);
   url.searchParams.set("step", step);
 
-  const res: MetricsResponse = await wfetch(url, { signal }).then((r) => r.json());
+  const res: FetchAllResponse = await wfetch(url, { signal }, dataObj).then((r) => r.json());
+
+  res.earnings.forEach((e) => {
+    e.timestamp = new Date(e.timestamp);
+  });
+  res.metrics.forEach((m) => {
+    m.startTime = new Date(m.startTime);
+  });
+
+  return res;
+}
+
+export async function fetchNodeMetrics(
+  nodeId: string,
+  startDate: Date,
+  endDate: Date,
+  step: string,
+  signal: AbortSignal
+) {
+  const url = new URL(METRICS_ORIGIN);
+
+  // This is only used for local testing.
+  const dataObj = {
+    event: {
+      queryStringParameters: {
+        nodeId,
+        startDate: startDate.getTime(),
+        endDate: endDate.getTime(),
+        step,
+      },
+    },
+  };
+
+  url.searchParams.set("nodeId", nodeId);
+  url.searchParams.set("startDate", `${startDate.getTime()}`);
+  url.searchParams.set("endDate", `${endDate.getTime()}`);
+  url.searchParams.set("step", step);
+
+  const res: MetricsResponse = await wfetch(url, { signal }, dataObj).then((r) => r.json());
 
   res.earnings.forEach((e) => {
     e.timestamp = new Date(e.timestamp);

--- a/src/api.ts
+++ b/src/api.ts
@@ -9,7 +9,7 @@ const METRICS_ORIGIN = import.meta.env.DEV
 
 // The current setup for local testing uses a Lambda gateway that
 // does not parse the requests to lambda events.
-const IS_LOCAL_LAMBDA = import.meta.env.LOCAL_GATEWAY;
+const IS_LOCAL_LAMBDA = import.meta.env.VITE_LOCAL_GATEWAY;
 /**
  * Fetch API wrapper that throws on 400+ http status.
  */
@@ -71,6 +71,9 @@ export async function fetchMetrics(
 
   const res: FetchAllResponse = await wfetch(url, { signal }, dataObj).then((r) => r.json());
 
+  // Uncomment for local testing
+  // res = res.data?.body;
+
   res.earnings.forEach((e) => {
     e.timestamp = new Date(e.timestamp);
   });
@@ -108,6 +111,9 @@ export async function fetchNodeMetrics(
   url.searchParams.set("step", step);
 
   const res: MetricsResponse = await wfetch(url, { signal }, dataObj).then((r) => r.json());
+
+  // Uncomment for local testing
+  // res = res.data?.body;
 
   res.earnings.forEach((e) => {
     e.timestamp = new Date(e.timestamp);

--- a/src/api.types.ts
+++ b/src/api.types.ts
@@ -14,10 +14,29 @@ export interface Earning {
   filAmount: number;
 }
 
+export interface GlobalStats {
+  totalEarnings: number;
+  totalRetrievals: number;
+  totalBandwidth: number;
+}
+
 export interface MetricsResponse {
-  nodes: Node[];
   metrics: Metric[];
   earnings: Earning[];
+  data?: any;
+}
+
+export interface FetchAllResponse extends MetricsResponse {
+  globalStats: GlobalStats;
+  perNodeMetrics: Array<object>;
+  nodes: Node[];
+}
+export interface GlobalMetrics {
+  totalEarnings: number;
+  totalRetrievals: number;
+  totalBandwidth: number;
+  perNodeMetrics: Array<object>;
+  nodes: Node[];
 }
 
 export interface RequestInit extends globalThis.RequestInit {

--- a/src/pages/dashboard/components/BandwidthChart.tsx
+++ b/src/pages/dashboard/components/BandwidthChart.tsx
@@ -9,13 +9,17 @@ interface BandwidthChartProps extends ChartProps {
 }
 
 export default function BandwidthChart(props: BandwidthChartProps) {
-  const { xScale, metrics, isLoading, spanGaps } = props;
+  const { xScale, metrics, isLoading, node, spanGaps } = props;
 
+  let title = "Global Bandwidth Served";
+  if (node) {
+    title = `Bandwidth Served for ${node}`;
+  }
   const options: ChartOptions<"line"> = {
     plugins: {
       title: {
         display: true,
-        text: "Bandwidth Served",
+        text: title,
       },
       tooltip: {
         callbacks: {

--- a/src/pages/dashboard/components/ChartContainer.tsx
+++ b/src/pages/dashboard/components/ChartContainer.tsx
@@ -9,6 +9,7 @@ export interface ChartProps {
   };
   xScale: object;
   spanGaps: number;
+  node: string | null;
 }
 
 export interface ChartContainerProps {
@@ -19,7 +20,7 @@ export interface ChartContainerProps {
 export default function ChartContainer(props: ChartContainerProps) {
   return (
     <div
-      className={`relative h-[300px] w-[100%] max-w-[600px] rounded bg-slate-900
+      className={`relative h-[350px] w-[100%] max-w-[600px] rounded bg-slate-900
             p-4 pt-2`}
     >
       {props.isLoading && <Loader className="absolute right-2 top-2" />}

--- a/src/pages/dashboard/components/EarningsChart.tsx
+++ b/src/pages/dashboard/components/EarningsChart.tsx
@@ -9,12 +9,16 @@ interface EarningsChartProps extends ChartProps {
 
 // Chart config must take into account that earnings are calculated once per day
 export default function EarningsChart(props: EarningsChartProps) {
-  const { earnings, xScale, isLoading } = props;
+  const { earnings, xScale, node, isLoading } = props;
+  let title = "Global Earnings";
+  if (node) {
+    title = `Earnings for ${node}`;
+  }
   const options: ChartOptions<"line"> = {
     plugins: {
       title: {
         display: true,
-        text: "Earnings",
+        text: title,
       },
       tooltip: {
         callbacks: {

--- a/src/pages/dashboard/components/NodesTable.tsx
+++ b/src/pages/dashboard/components/NodesTable.tsx
@@ -1,0 +1,97 @@
+import bytes from "bytes";
+import { AgGridReact } from "ag-grid-react";
+import { useEffect, useState } from "react";
+import ChartContainer from "./ChartContainer";
+import HTMLTooltip from "../../../components/StatsGrid/HTMLTooltip";
+
+import { CopyIcon, ProjectRoadmapIcon, SyncIcon } from "@primer/octicons-react";
+import copy from "copy-text-to-clipboard";
+import classNames from "classnames";
+import GridButton from "../../../components/StatsGrid/GridButton";
+
+// Chart config must take into account that earnings are calculated once per day
+export default function NodesTable(props: any) {
+  const setSelectedNode = props.setSelectedNode;
+  const [rowData, setRowData] = useState(props.metrics);
+
+  const [columnDefs] = useState([
+    {
+      width: 40,
+      suppressSizeToFit: true,
+      tooltipValueGetter: () => "Render node info",
+      cellRenderer: (params: any) => {
+        return (
+          <button type="button" onClick={() => setSelectedNode(params.data.nodeId)}>
+            <ProjectRoadmapIcon className={classNames("cursor-pointer text-slate-600 hover:text-slate-500")} />
+          </button>
+        );
+      },
+    },
+    {
+      field: "nodeId",
+      filter: true,
+      floatingFilter: true,
+      tooltipComponent: HTMLTooltip,
+      headerTooltip: "<div> Unique ID of the node </div>",
+
+      cellRenderer: (params: any) => {
+        return (
+          <>
+            <div>
+              <button className="w-20"> {params.data.idShort} </button>
+              {"   "}
+
+              <button type="button" onClick={() => copy(params.data.nodeId)}>
+                <CopyIcon className="cursor-pointer text-slate-600 hover:text-slate-500" />
+              </button>
+            </div>
+          </>
+        );
+      },
+      valueGetter: (params: any) => {
+        return params.data.idShort;
+      },
+      tooltipValueGetter: (params: any) => {
+        return [`Full ID: ${params.data.nodeId}`];
+      },
+    },
+    {
+      field: "numBytes",
+      headerName: "Bandwidth Served",
+      sortable: true,
+      cellRenderer: (params: any) => {
+        return bytes(params.data.numBytes, { unitSeparator: " " });
+      },
+    },
+    {
+      field: "numRequests",
+      headerName: "Retrievals",
+      sortable: true,
+      cellRenderer: (params: any) => {
+        return params.data.numRequests.toLocaleString();
+      },
+    },
+  ]);
+
+  useEffect(() => {
+    setRowData(props.metrics);
+  }, [props.metrics]);
+
+  return (
+    <ChartContainer isLoading={false}>
+      <div>
+        <GridButton onClick={() => setSelectedNode(null)} className="m-2 min-w-[155px]">
+          <SyncIcon className="-ml-0.5 mr-2 h-4 w-4" aria-hidden="true" /> Reset Charts to Global
+        </GridButton>
+      </div>
+      <div className="ag-theme-balham-dark ag-theme-saturn h-full max-h-72 w-auto max-w-[600px]">
+        <AgGridReact
+          rowData={rowData}
+          columnDefs={columnDefs}
+          tooltipShowDelay={0} // show without delay on mouse enter
+          tooltipHideDelay={99999} // do not hide unless mouse leaves
+        ></AgGridReact>
+      </div>
+    </ChartContainer>
+  );
+}

--- a/src/pages/dashboard/components/RequestsChart.tsx
+++ b/src/pages/dashboard/components/RequestsChart.tsx
@@ -8,12 +8,17 @@ interface RequestsChartProps extends ChartProps {
 }
 
 export default function RequestsChart(props: RequestsChartProps) {
-  const { metrics, xScale, isLoading, spanGaps } = props;
+  const { metrics, xScale, node, isLoading, spanGaps } = props;
+
+  let title = "Global Retrievals";
+  if (node) {
+    title = `Retrievals for ${node}`;
+  }
   const options: ChartOptions<"line"> = {
     plugins: {
       title: {
         display: true,
-        text: "Number of Retrievals",
+        text: title,
       },
     },
     scales: {

--- a/test/e2e/App.test.tsx
+++ b/test/e2e/App.test.tsx
@@ -4,7 +4,7 @@ import type { PreviewServer } from "vite";
 import puppeteer from "puppeteer";
 import type { Browser, Page } from "puppeteer";
 
-const TEST_FILE_ADDRESS = "f16m5slrkc6zumruuhdzn557a5sdkbkiellron4qa";
+const TEST_FIL_ADDRESS = "f16m5slrkc6zumruuhdzn557a5sdkbkiellron4qa";
 
 describe("website mode", async () => {
   let server: PreviewServer;
@@ -25,7 +25,7 @@ describe("website mode", async () => {
   });
 
   test("navbar should be visible", async () => {
-    await page.goto(`${server.resolvedUrls.local[0]}/address/${TEST_FILE_ADDRESS}`);
+    await page.goto(`${server.resolvedUrls.local[0]}/address/${TEST_FIL_ADDRESS}`);
     const navbar = (await page.$("[data-test-id=navbar]"))!;
     expect(navbar).not.toBe(null);
   }, 60_000);


### PR DESCRIPTION
## Changes:
User can now see a table of per node stats associated with their FIL address:
<img width="1306" alt="Screen Shot 2023-03-16 at 9 20 40 PM" src="https://user-images.githubusercontent.com/43304401/225787840-d0e9bce4-9264-4662-9b1b-a75581a6fc59.png">

User can click on a given node to switch the charts to present a specific node's stats: 
<img width="1324" alt="Screen Shot 2023-03-16 at 9 21 55 PM" src="https://user-images.githubusercontent.com/43304401/225788006-9282bb7d-5023-4f17-8630-1771e0b5ce40.png">


User can click on the "Reset charts to global" button to switch back to the global view shown in the first image:
<img width="206" alt="Screen Shot 2023-03-16 at 9 22 14 PM" src="https://user-images.githubusercontent.com/43304401/225788059-204e16e5-dfc6-44bd-b9a7-ed0be02b42d1.png">