### PR TITLE
feat: UI for Uptime Requirement Implementation

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -63,7 +63,7 @@ export async function fetchMetrics(
     e.timestamp = new Date(e.timestamp);
   });
   res.metrics.forEach((m) => {
-    m.startTime = new Date(m.startTime);
+    m.timeStamp = new Date(m.timeStamp);
   });
 
   return res;
@@ -101,7 +101,7 @@ export async function fetchNodeMetrics(
     e.timestamp = new Date(e.timestamp);
   });
   res.metrics.forEach((m) => {
-    m.startTime = new Date(m.startTime);
+    m.timeStamp = new Date(m.timeStamp);
   });
 
   return res;

--- a/src/api.types.ts
+++ b/src/api.types.ts
@@ -4,7 +4,7 @@ export interface Node {
 }
 
 export interface Metric {
-  startTime: Date;
+  timeStamp: Date;
   numBytes: number;
   numRequests: number;
 }
@@ -14,6 +14,15 @@ export interface Earning {
   filAmount: number;
 }
 
+interface NodeStats {
+  nodeId: string;
+  filAmount: number;
+  numBytes: number;
+  numRequests: number;
+  payoutStatus: string;
+  uptimeCompletion: number | undefined;
+  state: string;
+}
 export interface GlobalStats {
   totalEarnings: number;
   totalRetrievals: number;
@@ -28,14 +37,14 @@ export interface MetricsResponse {
 
 export interface FetchAllResponse extends MetricsResponse {
   globalStats: GlobalStats;
-  perNodeMetrics: Array<object>;
+  perNodeMetrics: Array<NodeStats>;
   nodes: Node[];
 }
 export interface GlobalMetrics {
   totalEarnings: number;
   totalRetrievals: number;
   totalBandwidth: number;
-  perNodeMetrics: Array<object>;
+  perNodeMetrics: Array<NodeStats>;
   nodes: Node[];
 }
 

--- a/src/pages/dashboard/components/BandwidthChart.tsx
+++ b/src/pages/dashboard/components/BandwidthChart.tsx
@@ -38,7 +38,7 @@ export default function BandwidthChart(props: BandwidthChartProps) {
   };
 
   const data = {
-    labels: metrics.map((m) => m.startTime),
+    labels: metrics.map((m) => m.timeStamp),
     datasets: [
       {
         data: metrics.map((m) => m.numBytes),

--- a/src/pages/dashboard/components/NodesTable.tsx
+++ b/src/pages/dashboard/components/NodesTable.tsx
@@ -43,6 +43,7 @@ export default function NodesTable(props: any) {
       filter: true,
       floatingFilter: true,
       tooltipComponent: HTMLTooltip,
+      minWidth: 120,
       headerTooltip: "<div> Unique ID of the node </div>",
 
       cellRenderer: (params: any) => {
@@ -67,6 +68,28 @@ export default function NodesTable(props: any) {
       },
     },
     {
+      field: "filEarned",
+      headerName: "Estimated Earnings",
+      sortable: true,
+      cellRenderer: (params: any) => {
+        return `${params.data.filAmount.toLocaleString()} FIL`;
+      },
+      valueGetter: (params: any) => {
+        return params.data.filAmount;
+      },
+    },
+    {
+      field: "payoutStatus",
+      headerName: "Payout Status",
+      width: 110,
+      cellRenderer: (params: any) => {
+        return params.data.payoutStatus;
+      },
+      tooltipValueGetter: (params: any) => {
+        return [renderStatusTooltip(params.data.payoutStatus)];
+      },
+    },
+    {
       field: "numBytes",
       headerName: "Bandwidth Served",
       sortable: true,
@@ -82,16 +105,6 @@ export default function NodesTable(props: any) {
         return params.data.numRequests.toLocaleString();
       },
     },
-    {
-      field: "payoutStatus",
-      headerName: "Payout Status",
-      cellRenderer: (params: any) => {
-        return params.data.payoutStatus;
-      },
-      tooltipValueGetter: (params: any) => {
-        return [renderStatusTooltip(params.data.payoutStatus)];
-      },
-    },
   ]);
 
   useEffect(() => {
@@ -99,7 +112,12 @@ export default function NodesTable(props: any) {
   }, [props.metrics]);
 
   if (gridRef.current && gridRef.current.api) {
-    gridRef.current.api.sizeColumnsToFit();
+    const allColumnIds: Array<any> = [];
+    const skipHeader = false;
+    gridRef.current.columnApi.getColumns().forEach((column: any) => {
+      allColumnIds.push(column.getId());
+    });
+    gridRef.current.columnApi.autoSizeColumns(allColumnIds, skipHeader);
   }
 
   return (
@@ -114,7 +132,6 @@ export default function NodesTable(props: any) {
           ref={gridRef}
           rowData={rowData}
           columnDefs={columnDefs}
-          // suppressHorizontalScroll={true}
           tooltipShowDelay={0} // show without delay on mouse enter
           tooltipHideDelay={99999} // do not hide unless mouse leaves
         ></AgGridReact>

--- a/src/pages/dashboard/components/NodesTable.tsx
+++ b/src/pages/dashboard/components/NodesTable.tsx
@@ -29,7 +29,6 @@ export default function NodesTable(props: any) {
     {
       width: 40,
       suppressSizeToFit: true,
-      tooltipValueGetter: () => "Render node info",
       cellRenderer: (params: any) => {
         return (
           <button type="button" onClick={() => setSelectedNode(params.data.nodeId)}>
@@ -37,6 +36,7 @@ export default function NodesTable(props: any) {
           </button>
         );
       },
+      tooltipValueGetter: () => "Render node info",
     },
     {
       field: "nodeId",
@@ -71,7 +71,7 @@ export default function NodesTable(props: any) {
       field: "filEarned",
       headerName: "Estimated Earnings",
       sortable: true,
-      cellRenderer: (params: any) => {
+      cellRenderer: (params: Record<any, any>) => {
         return `${params.data.filAmount.toLocaleString()} FIL`;
       },
       valueGetter: (params: any) => {

--- a/src/pages/dashboard/components/RequestsChart.tsx
+++ b/src/pages/dashboard/components/RequestsChart.tsx
@@ -27,7 +27,7 @@ export default function RequestsChart(props: RequestsChartProps) {
   };
 
   const data = {
-    labels: metrics.map((m) => m.startTime),
+    labels: metrics.map((m) => m.timeStamp),
     datasets: [
       {
         data: metrics.map((m) => m.numRequests),


### PR DESCRIPTION
## Changes:
Added a payout status column to the nodes table:
<img width="529" alt="Screen Shot 2023-04-28 at 3 02 44 PM" src="https://user-images.githubusercontent.com/43304401/235168990-3195e9cf-7d68-4eab-ab31-b08afbf0a3a4.png">


Added node specific info in the "Overview" section when a user clicks a given node:
- A `state` of the node.
- A progress bar showing the qualification of the uptime requirement. 
- A payout status. 

<img width="636" alt="Screen Shot 2023-04-28 at 3 05 19 PM" src="https://user-images.githubusercontent.com/43304401/235169640-5da7b830-83c7-4a00-8490-a00ec3d53c16.png">

cc @gruns for review on this UI