### PR TITLE
opt into perNode metrics

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -56,6 +56,7 @@ export async function fetchMetrics(
   url.searchParams.set("startDate", `${startDate.getTime()}`);
   url.searchParams.set("endDate", `${endDate.getTime()}`);
   url.searchParams.set("step", step);
+  url.searchParams.set("perNode", "true");
 
   const res: FetchAllResponse = await wfetch(url, { signal }, dataObj).then((r) => r.json());
 


### PR DESCRIPTION
fixes: https://github.com/filecoin-saturn/homepage/issues/185
depends on: https://github.com/filecoin-saturn/log-ingestor/pull/72

Dashboard explicitly asks for `perNode` metrics.