### PR TITLE
FILE-4 - move the node list from a char box in the upper right to a dedicated column on the left side of the page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ export default function App() {
           <Route path=":encodedState" element={<Stats />} />
         </Route>
         <Route path="/address" element={<Home />} />
+        <Route path="/address/:address/:nodeId" element={<Dashboard />} />
         <Route path="/address/:address" element={<Dashboard />} />
       </Routes>
       <AuthenticateModal />

--- a/src/api.types.ts
+++ b/src/api.types.ts
@@ -14,7 +14,7 @@ export interface Earning {
   filAmount: number;
 }
 
-interface NodeStats {
+export interface NodeStats {
   nodeId: string;
   filAmount: number;
   numBytes: number;
@@ -59,4 +59,10 @@ export enum TimePeriod {
   MONTH = "30 Days",
   THREE_MONTHS = "90 Days",
   ONE_YEAR = "365 Days",
+}
+
+export enum PayoutStatus {
+  Postponed = "postponed",
+  Pending = "pending",
+  Valid = "valid",
 }

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect } from "react";
+
+type WindowSize = {
+  width: number;
+  height: number;
+};
+
+export const useWindowSize = (): WindowSize => {
+  const [windowSize, setWindowSize] = useState<WindowSize>({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+
+    window.addEventListener("resize", handleResize);
+    handleResize();
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return windowSize;
+};
+
+export const useWindowWidthIsSmallerThan = (value: number): boolean => {
+  const { width } = useWindowSize();
+  return width < value;
+};

--- a/src/pages/dashboard/components/ChartContainer.tsx
+++ b/src/pages/dashboard/components/ChartContainer.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import Loader from "../../../components/Loader";
+import classNames from "classnames";
 
 export interface ChartProps {
   isLoading: boolean;
@@ -9,19 +10,22 @@ export interface ChartProps {
   };
   xScale: object;
   spanGaps: number;
-  node: string | null;
+  node?: string | null;
 }
 
 export interface ChartContainerProps {
   isLoading: boolean;
   children: ReactNode;
+  fullHeight?: boolean;
 }
 
 export default function ChartContainer(props: ChartContainerProps) {
   return (
     <div
-      className={`relative h-[350px] w-[100%] max-w-[600px] rounded bg-slate-900
-            p-4 pt-2`}
+      className={classNames("relative w-[100%] max-w-[600px] rounded bg-slate-900 p-4 pt-2", {
+        "h-[350px]": !props.fullHeight,
+        "h-full": props.fullHeight,
+      })}
     >
       {props.isLoading && <Loader className="absolute right-2 top-2" />}
       {props.children}

--- a/src/pages/dashboard/components/NodesTable.tsx
+++ b/src/pages/dashboard/components/NodesTable.tsx
@@ -3,142 +3,227 @@ import { AgGridReact } from "ag-grid-react";
 import { useEffect, useRef, useState } from "react";
 import ChartContainer from "./ChartContainer";
 import HTMLTooltip from "../../../components/StatsGrid/HTMLTooltip";
-
-import { CopyIcon, ProjectRoadmapIcon, ListUnorderedIcon } from "@primer/octicons-react";
+import {
+  CopyIcon,
+  ListUnorderedIcon,
+  CheckCircleFillIcon,
+  ClockFillIcon,
+  ProjectRoadmapIcon,
+} from "@primer/octicons-react";
 import copy from "copy-text-to-clipboard";
 import classNames from "classnames";
+import { Column, ITooltipParams, ValueGetterParams, ICellRendererParams, ColDef } from "ag-grid-community";
+
 import GridButton from "../../../components/StatsGrid/GridButton";
 import { PAYOUT_STATUS_MAPPING } from "..";
+import { NodeStats, PayoutStatus } from "../../../api.types";
+import { useWindowWidthIsSmallerThan } from "../../../hooks/useWindowSize";
+import { Link, useParams, useSearchParams, useNavigate } from "react-router-dom";
+import { shortenNumber } from "../../../utils/shortenNumber";
+
+interface NodeTableProps {
+  metrics: NodeStats[];
+  isLoading: boolean;
+}
+
+interface NodeStatsParams extends NodeStats {
+  idShort: string;
+}
 
 // Chart config must take into account that earnings are calculated once per day
-export default function NodesTable(props: any) {
-  const setSelectedNode = props.setSelectedNode;
+export default function NodeTable(props: NodeTableProps) {
+  const { address = "" } = useParams();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const periodFilter = searchParams.get("period");
   const [rowData, setRowData] = useState(props.metrics);
-  const gridRef = useRef<any>(null);
+  const gridRef = useRef<AgGridReact>(null);
+  const isCard = useWindowWidthIsSmallerThan(1024);
 
-  const renderStatusTooltip = (status: string) => {
+  const getSelectedNodeIdUrl = (nodeId: string) => {
+    return `/address/${address}/${nodeId}${periodFilter ? `?period=${periodFilter}` : ""}`;
+  };
+
+  const renderStatusTooltip = (status: PayoutStatus) => {
     switch (status) {
-      case "postponed":
-        return "Earnings for this node are postponed to the following month due to late node registration";
-      case "pending":
-        return "Earnings for this node this month are pending until the uptime requirement is satisfied";
-      case "valid":
-        return "Earnings for this node are valid for this month";
+      case PayoutStatus.Postponed:
+        return `(${PAYOUT_STATUS_MAPPING[status]}) Earnings for this node are postponed to the following month due to late node registration`;
+      case PayoutStatus.Pending:
+        return `(${PAYOUT_STATUS_MAPPING[status]}) Earnings for this node this month are pending until the uptime requirement is satisfied`;
+      case PayoutStatus.Valid:
+        return `(${PAYOUT_STATUS_MAPPING[status]}) Earnings for this node are valid for this month`;
     }
   };
-  const [columnDefs] = useState([
-    {
-      width: 40,
-      suppressSizeToFit: true,
-      cellRenderer: (params: any) => {
+
+  const renderPayoutIcon = (status: PayoutStatus) => {
+    switch (status) {
+      case PayoutStatus.Postponed:
+        return PAYOUT_STATUS_MAPPING[status];
+      case PayoutStatus.Pending:
+        return <ClockFillIcon className="cursor-pointer text-yellow-300" />;
+      case PayoutStatus.Valid:
+        return <CheckCircleFillIcon className="cursor-pointer text-green-500" />;
+    }
+  };
+
+  // columns for Card
+  const cardColumnDef: ColDef<NodeStats> = {
+    maxWidth: 40,
+    suppressSizeToFit: true,
+    cellRenderer: (params: ICellRendererParams<NodeStatsParams>) => {
+      if (address) {
         return (
-          <button type="button" onClick={() => setSelectedNode(params.data.nodeId)}>
+          <Link className="w-20" to={params?.data?.nodeId ? getSelectedNodeIdUrl(params?.data?.nodeId) : ""}>
             <ProjectRoadmapIcon className={classNames("cursor-pointer text-slate-600 hover:text-slate-500")} />
-          </button>
+          </Link>
         );
-      },
-      tooltipValueGetter: () => "Render node info",
+      }
     },
+    tooltipValueGetter: () => "Render node info",
+  };
+  // common columns
+  const commonColumnDefs: ColDef<NodeStats>[] = [
     {
       field: "nodeId",
       filter: true,
       floatingFilter: true,
       tooltipComponent: HTMLTooltip,
-      minWidth: 120,
+      maxWidth: !isCard ? 95 : 120,
       headerTooltip: "<div> Unique ID of the node </div>",
 
-      cellRenderer: (params: any) => {
-        return (
-          <>
-            <div>
-              <button className="w-20"> {params.data.idShort} </button>
-              {"   "}
-
-              <button type="button" onClick={() => copy(params.data.nodeId)}>
-                <CopyIcon className="cursor-pointer text-slate-600 hover:text-slate-500" />
+      cellRenderer: (params: ICellRendererParams<NodeStatsParams>) => {
+        if (address) {
+          return (
+            <div className={classNames({ "group relative": !isCard, "flex justify-around": isCard })}>
+              <Link className="w-20" to={params?.data?.nodeId ? getSelectedNodeIdUrl(params?.data?.nodeId) : ""}>
+                {params?.data?.idShort}
+              </Link>
+              <button
+                className={classNames({ "invisible absolute -right-2 group-hover:visible": !isCard })}
+                type="button"
+                onClick={() => params?.data?.nodeId && copy(params?.data?.nodeId)}
+              >
+                <CopyIcon className="block cursor-pointer text-slate-600 hover:text-slate-500 " />
               </button>
             </div>
-          </>
-        );
+          );
+        }
       },
-      valueGetter: (params: any) => {
-        return params.data.idShort;
+      valueGetter: (params: ValueGetterParams<NodeStats>) => {
+        return params.data?.nodeId;
       },
-      tooltipValueGetter: (params: any) => {
-        return [`Full ID: ${params.data.nodeId}`];
+      tooltipValueGetter: (params: ITooltipParams<NodeStats>) => {
+        return [`Full ID: ${params?.data?.nodeId}`];
       },
     },
     {
       field: "filEarned",
-      headerName: "Estimated Earnings",
+      headerName: `Estimated Earnings ${!isCard ? "(FIL)" : ""}`,
+      headerTooltip: "Estimated Earnings (FIL)",
       sortable: true,
-      cellRenderer: (params: Record<any, any>) => {
-        return `${params.data.filAmount.toLocaleString()} FIL`;
+      maxWidth: !isCard ? 75 : undefined,
+      cellRenderer: (params: ICellRendererParams<NodeStatsParams>) => {
+        return `${params?.data?.filAmount.toLocaleString()} ${isCard ? "FIL" : ""}`;
       },
-      valueGetter: (params: any) => {
-        return params.data.filAmount;
+      valueGetter: (params: ValueGetterParams<NodeStats>) => {
+        return params?.data?.filAmount;
+      },
+      tooltipValueGetter: (params: ITooltipParams<NodeStats>) => {
+        return params?.data?.filAmount;
       },
     },
     {
       field: "payoutStatus",
       headerName: "Payout Eligibility",
-      width: 110,
-      cellRenderer: (params: any) => {
-        const payoutStatus = params.data.payoutStatus;
-
-        return PAYOUT_STATUS_MAPPING[payoutStatus];
+      headerTooltip: "Payout Eligibility",
+      maxWidth: !isCard ? 70 : undefined,
+      cellRenderer: (params: ICellRendererParams<NodeStatsParams>) => {
+        const payoutStatus = params?.data?.payoutStatus;
+        if (payoutStatus) {
+          return isCard ? (
+            PAYOUT_STATUS_MAPPING[payoutStatus]
+          ) : (
+            <div className="flex h-full items-center justify-center">
+              {renderPayoutIcon(payoutStatus as PayoutStatus)}
+            </div>
+          );
+        }
       },
-      tooltipValueGetter: (params: any) => {
-        return [renderStatusTooltip(params.data.payoutStatus)];
+      tooltipValueGetter: (params: ITooltipParams<NodeStats>) => {
+        return [params?.data?.payoutStatus ? renderStatusTooltip(params?.data?.payoutStatus as PayoutStatus) : ""];
       },
     },
     {
       field: "numBytes",
       headerName: "Bandwidth Served",
+      headerTooltip: " Bandwidth Served ",
       sortable: true,
-      cellRenderer: (params: any) => {
-        return bytes(params.data.numBytes, { unitSeparator: " " });
+      maxWidth: !isCard ? 75 : undefined,
+      cellRenderer: (params: ICellRendererParams<NodeStatsParams>) => {
+        return params?.data?.numBytes && bytes(params?.data?.numBytes, { unitSeparator: " " });
+      },
+      tooltipValueGetter: (params: ITooltipParams<NodeStats>) => {
+        return params?.data?.numBytes && bytes(params?.data?.numBytes, { unitSeparator: " " });
       },
     },
     {
       field: "numRequests",
       headerName: "Retrievals",
+      headerTooltip: " Retrievals ",
       sortable: true,
-      cellRenderer: (params: any) => {
-        return params.data.numRequests.toLocaleString();
+      maxWidth: !isCard ? 70 : undefined,
+      cellRenderer: (params: ICellRendererParams<NodeStatsParams>) => {
+        if (params?.data?.numRequests) {
+          return isCard
+            ? params.data.numRequests.toLocaleString()
+            : shortenNumber(params?.data?.numRequests).toLocaleString();
+        }
+      },
+      tooltipValueGetter: (params: ITooltipParams<NodeStats>) => {
+        return [params?.data?.numRequests];
       },
     },
-  ]);
+  ];
+
+  const [columnDefs, setColumnDefs] = useState<ColDef<NodeStats>[]>(
+    isCard ? [cardColumnDef, ...commonColumnDefs] : commonColumnDefs
+  );
 
   useEffect(() => {
     setRowData(props.metrics);
-  }, [props.metrics]);
+    setColumnDefs(isCard ? [cardColumnDef, ...commonColumnDefs] : commonColumnDefs);
+  }, [props.metrics, isCard]);
 
   if (gridRef.current && gridRef.current.api) {
-    const allColumnIds: Array<any> = [];
+    const allColumnIds: Array<string> = [];
     const skipHeader = false;
-    gridRef.current.columnApi.getColumns().forEach((column: any) => {
+    gridRef.current.columnApi.getColumns()?.forEach((column: Column) => {
       allColumnIds.push(column.getId());
     });
     gridRef.current.columnApi.autoSizeColumns(allColumnIds, skipHeader);
   }
 
   return (
-    <ChartContainer isLoading={false}>
-      <div>
-        <GridButton onClick={() => setSelectedNode(null)} className="m-2 min-w-[155px]">
-          <ListUnorderedIcon className="-ml-0.5 mr-2 h-4 w-4" aria-hidden="true" /> Reset Charts to Include All Nodes
-        </GridButton>
-      </div>
-      <div className="ag-theme-balham-dark ag-theme-saturn h-full max-h-72 w-auto max-w-[600px]">
-        <AgGridReact
-          ref={gridRef}
-          rowData={rowData}
-          columnDefs={columnDefs}
-          tooltipShowDelay={0} // show without delay on mouse enter
-          tooltipHideDelay={99999} // do not hide unless mouse leaves
-        ></AgGridReact>
-      </div>
-    </ChartContainer>
+    <div className="inline-flex h-full w-full justify-center lg:w-[420px] ">
+      <ChartContainer isLoading={props.isLoading} fullHeight={!isCard}>
+        <div>
+          <GridButton
+            onClick={() => navigate(`/address/${address}${periodFilter ? `?period=${periodFilter}` : ""}`)}
+            className="m-2 min-w-[155px]"
+          >
+            <ListUnorderedIcon className="-ml-0.5 mr-2 h-4 w-4" aria-hidden="true" /> Reset Charts to Include All Nodes
+          </GridButton>
+        </div>
+        <div className="ag-theme-balham-dark ag-theme-saturn h-full w-auto max-w-[600px] pb-10">
+          <AgGridReact
+            ref={gridRef}
+            rowData={rowData}
+            columnDefs={columnDefs}
+            tooltipShowDelay={0} // show without delay on mouse enter
+            tooltipHideDelay={99999} // do not hide unless mouse leaves
+          />
+        </div>
+      </ChartContainer>
+    </div>
   );
 }

--- a/src/pages/dashboard/components/NodesTable.tsx
+++ b/src/pages/dashboard/components/NodesTable.tsx
@@ -58,7 +58,7 @@ export default function NodeTable(props: NodeTableProps) {
   const renderPayoutIcon = (status: PayoutStatus) => {
     switch (status) {
       case PayoutStatus.Postponed:
-        return PAYOUT_STATUS_MAPPING[status];
+        return <ClockFillIcon className="cursor-pointer text-gray-300" />;
       case PayoutStatus.Pending:
         return <ClockFillIcon className="cursor-pointer text-yellow-300" />;
       case PayoutStatus.Valid:

--- a/src/utils/shortenNumber.ts
+++ b/src/utils/shortenNumber.ts
@@ -1,0 +1,12 @@
+const MAGNITUDE_SUFFIXES = ["", "k", "M", "G", "T", "P", "E", "Z"];
+
+export const shortenNumber = (num: number) => {
+  let unitIndex = 0;
+
+  while (num >= 1000) {
+    num /= 1000;
+    unitIndex++;
+  }
+
+  return Math.floor(num) + MAGNITUDE_SUFFIXES[unitIndex];
+};


### PR DESCRIPTION
### What does this PR do?

-  Move the node list from a char box in the upper right to a dedicated column on the left side of the page
-  2nd column, node id, remains, but the copy button is hidden by default and only becomes displayed, position: absolute on mouseover. thus it takes up no permanent, static space
-  4th column, payout status, can be shrunk by replacing valid and pending with two different icons that, on mouseover, show the full Valid or Pending. for example, a green checkbox logo that, on mouseover, displays Valid and a yellow clock logo that, on mouseover, displays Pending
- 6th column, retrievals, shorten from the full 72,102, 4,003,018 to use metric suffix: 72k, 4M, etc

### Issue reference
- https://github.com/filecoin-saturn/L1-dashboard/issues/38

### Demo video/scrennshot:
- https://www.loom.com/share/b5bbc2c74e5b4aceae96f419c952482f?sid=31746fe1-bdb1-4044-a914-4efb8e05f082

> This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.
