### PR TITLE
FILE-20 - always show multiple badges in the UI

### DIFF
--- a/src/components/StatsGrid/StatsGridConfig.tsx
+++ b/src/components/StatsGrid/StatsGridConfig.tsx
@@ -124,14 +124,34 @@ export const columnDefs = [
     },
     valueFormatter: (params: any) => params.data.idShort,
     cellRenderer: (params: any) => {
+      const badges = [];
+      const badgeMap: Record<string, string> = {
+        sunrise: "🌅️",
+        core: "⭐️",
+        cassini: "🛰",
+      };
+
+      for (const property in badgeMap) {
+        if (params.data[property as keyof typeof badgeMap]) {
+          badges.push(badgeMap[property]);
+        }
+      }
+
       return (
         <>
           <button type="button" onClick={() => copy(params.data.id)}>
             <CopyIcon className="cursor-pointer text-slate-600 hover:text-slate-500" />
           </button>{" "}
-          {params.valueFormatted} {params.data.sunrise ? <span>🌅️</span> : null}
-          {params.data.core ? <span>⭐️</span> : null}
-          {params.data.cassini ? <span>🛰</span> : null}
+          {params.valueFormatted}
+          <div className="pl-4">
+            {badges.map((badge, idx) => {
+              return (
+                <span className="ml-1" key={idx}>
+                  {badge}
+                </span>
+              );
+            })}
+          </div>
         </>
       );
     },

--- a/src/components/StatsGrid/StatsGridConfig.tsx
+++ b/src/components/StatsGrid/StatsGridConfig.tsx
@@ -143,7 +143,7 @@ export const columnDefs = [
             <CopyIcon className="cursor-pointer text-slate-600 hover:text-slate-500" />
           </button>{" "}
           {params.valueFormatted}
-          <div className="pl-4">
+          <div className="absolute top-[15px] pl-4">
             {badges.map((badge, idx) => {
               return (
                 <span className="ml-1" key={idx}>


### PR DESCRIPTION
### What does this PR do?
This PR breaks the badge(s) on the node to be on the next line, thereby preventing the current issue of hiding badges when more than 1.

### Issue reference:
https://github.com/filecoin-saturn/L1-dashboard/issues/54

### Demo Video
Loom Video: https://www.loom.com/share/b487ebd4964642e38e8b4838ff15188e


